### PR TITLE
PXD-1430 Feat/simple metadata

### DIFF
--- a/pidgin/app.py
+++ b/pidgin/app.py
@@ -47,9 +47,9 @@ def get_metadata_dict(object_id):
     Create a dictionary containing the metadata for a given object_id.
     """
     response = request_metadata(object_id) # query to peregrine
-    dict = flatten_dict(response)
-    dict['citation'] = generate_ciation(dict)
-    return remove_unused_fields(dict) # translate the response to a dictionary
+    metadata = flatten_dict(response)
+    metadata['citation'] = generate_citation(metadata)
+    return remove_unused_fields(metadata) # translate the response to a dictionary
 
 
 def translate_dict_to_bibtex(d):
@@ -83,16 +83,14 @@ def flatten_dict(d):
         raise NoCoreMetadataException(error)
     return flat_d
 
-def generate_ciation(metadata_dict):
+def generate_citation(metadata_dict):
     """
     Generate a citation from the other metadata.
     """
-    creator = metadata_dict.get('creator')
-    year = metadata_dict.get('updated_datetime').split('-')[0]
-    title = metadata_dict.get('title')
-    publisher = metadata_dict.get('publisher')
-    guid = metadata_dict.get('object_id')
-    return '{}, {}: {}. {}, {}.'.format(creator, year, title, publisher, guid)
+    format_args = dict(metadata_dict)
+    format_args['year'] = format_args.pop('updated_datetime').split('-')[0]
+    format_string = '{creator}, {year}: {title}. {publisher}, {object_id}'
+    return format_string.format(**format_args)
 
 
 def remove_unused_fields(d):

--- a/pidgin/app.py
+++ b/pidgin/app.py
@@ -124,13 +124,11 @@ def request_metadata(object_id):
     Write a query and transmit it to send_query().
     """
     file_type = get_file_type(object_id)
-    query_txt = build_query(object_id, file_type, True)
-    response = send_query(query_txt)
+    response = send_query(build_query(object_id, file_type, True))
 
     # if the file has no core metadata, get the other metadata only
     if not has_core_metadata(response, file_type):
-        simple_query_txt = build_query(object_id, file_type, False)
-        response = send_query(simple_query_txt)
+        response = send_query(build_query(object_id, file_type))
 
     return response
 
@@ -147,7 +145,7 @@ def has_core_metadata(response, file_type):
     return True
 
 
-def build_query(object_id, file_type, get_core_metadata):
+def build_query(object_id, file_type, get_core_metadata = False):
     """
     Build the query to get the core metadata.
 

--- a/pidgin/app.py
+++ b/pidgin/app.py
@@ -75,9 +75,10 @@ def flatten_dict(d):
         data_type = list(d['data'].keys())[0]
         for k, v in d['data'][data_type][0].items():
             if k == 'core_metadata_collections':
-                # object_id is unique so the list should only contain one item
-                for k, v in v[0].items():
-                    flat_d[k] = v
+                if v:
+                    # object_id is unique so the list should only contain one item
+                    for _k, _v in v[0].items():
+                        flat_d[_k] = _v
             else:
                 flat_d[k] = v
     except (AttributeError, IndexError):

--- a/pidgin/app.py
+++ b/pidgin/app.py
@@ -8,7 +8,18 @@ from pidgin.errors import *
 app = flask.Flask(__name__)
 
 
-@app.route('/json/<path:object_id>') # 'path' allows the use of '/' in the id
+@app.route('/<path:object_id>')
+def get_core_metadata(object_id):
+    """
+    Get core metadata from an object_id.
+    """
+    accept = flask.request.headers.get('Accept')
+    if accept == "x-bibtex":
+        return get_bibtex_metadata(object_id)
+    else: # accept == "application/json" or no accept header
+        return get_json_metadata(object_id)
+
+
 def get_json_metadata(object_id):
     """
     Get core metadata as JSON from an object_id.
@@ -20,7 +31,6 @@ def get_json_metadata(object_id):
         return e.message, e.code
 
 
-@app.route('/bibtex/<path:object_id>')
 def get_bibtex_metadata(object_id):
     """
     Get core metadata as BibTeX from an object_id.

--- a/pidgin/constants.py
+++ b/pidgin/constants.py
@@ -1,0 +1,5 @@
+CITATION_FIELDS = ['creator', 'updated_datetime', 'title', 'publisher', 'object_id']
+
+METADATA_QUERY_FIELDS = ['type', 'file_name', 'data_format', 'file_size', 'project_id', 'object_id', 'updated_datetime']
+
+CORE_METADATA_QUERY_FIELDS = ['title', 'description', 'creator', 'contributor', 'coverage', 'language', 'publisher', 'rights', 'source', 'subject']

--- a/tests/app_test.py
+++ b/tests/app_test.py
@@ -14,15 +14,20 @@ def test_flatten_dict():
     expected = {"creator": "creator_test", "description": "description_test", "file_name_test": "file_name", "object_id": "object_id_test"}
     assert output == expected
 
-def test_flatten_dict_raises_exception():
+def test_flatten_dict_without_core_metadata():
     """
     An exception should be raised if the core_metadata_collections field does not contain any data.
     """
-    input = {'data': {'data_type_test': [{'core_metadata_collections': [], "file_name_test": "file_name", "object_id": "object_id_test"}]}}
-    with pytest.raises(NoCoreMetadataException):
-        flatten_dict(input)
+    input1 = {'data': {'data_type_test': [{'core_metadata_collections': [], "file_name_test": "file_name", "object_id": "object_id_test"}]}}
+    output = flatten_dict(input1)
+    expected = {"file_name_test": "file_name", "object_id": "object_id_test"}
+    assert output == expected
 
-def test_flatten_dict_raises_exception_with_details():
+    input2 = {'data': {'data_type_test': [{"file_name_test": "file_name", "object_id": "object_id_test"}]}}
+    output = flatten_dict(input2)
+    assert output == expected
+
+def test_flatten_dict_raises_exception():
     """
     An exception should be raised if a requested field was not found for this file. The details of the error should be in the exception message.
     """


### PR DESCRIPTION
If a file doesn't have core_metadata_collections, only retrieve the other metadata instead of returning an error. This is so that the landing page will not be broken if called on a file without core metadata