### PR TITLE
chore(image-tag): use python-nginx image tag instead of master

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # To check running container: docker exec -it pidgin /bin/bash
 
 
-FROM quay.io/cdis/python-nginx:master
+FROM quay.io/cdis/python-nginx:1.3.0
 
 
 ENV appname=pidgin


### PR DESCRIPTION
Use python-nginx image tag

### New Features


### Breaking Changes


### Bug Fixes


### Improvements
- Use the image tag instead of master

### Dependency updates


### Deployment changes

