### PR TITLE
fix(qa): Freeze stable version of Werkzeug to unblock py tests

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -2,5 +2,6 @@ codacy-coverage
 pytest==3.2.3
 pytest-cov==2.5.1
 pytest-flask==0.10.0
+Werkzeug==0.16.1
 flasgger==0.9.1
 PyYAML==5.1


### PR DESCRIPTION
Werkzeug package got new version(1.0.0) update 4 days ago.
The update is not backward compatible, many Flask based libraries are breaking.

A simple fix is that, install Werkzeug==0.16.0, which is working perfectly.
Install this version before installing flask or after it, doesn't really matter, things will work as expected.

As per:
https://github.com/noirbizarre/flask-restplus/issues/777

This is a temporary fix until we upgrade our `pytest-flask` lib.