### PR TITLE
chore(pytest): fix werkzeug ImportError

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,6 +1,6 @@
 codacy-coverage
-pytest==3.2.3
+pytest==3.6.0
 pytest-cov==2.5.1
-pytest-flask==0.10.0
+pytest-flask==0.15.1
 flasgger==0.9.1
 PyYAML==5.1


### PR DESCRIPTION
Fixes #33 

See https://github.com/pytest-dev/pytest-flask/issues/106

### Dependency updates
- pytest-flask to 0.15.1 to fix werkzeug ImportError, and pytest to 3.6.0 for pytest-flask
