### PR TITLE
Update requirements.txt 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ ENV appname=pidgin
 
 RUN apk update \
     && apk add postgresql-libs postgresql-dev libffi-dev libressl-dev \
-    && apk add linux-headers musl-dev gcc \
+    && apk add linux-headers musl-dev gcc g++ \
     && apk add curl bash git vim
 
 COPY . /$appname

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 cdislogging==1.0.0
 Flask==1.0.2
 requests==2.20.0
+psqlgraph==3.0.1


### PR DESCRIPTION
Quick update to unblock April releases

Bump up `psqlgraph` to get rid of `py2neo`


### Dependency updates
- psqlgraph: up to `3.0.1`

