### PR TITLE
Do not crash when Peregrine returns no data

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,6 +13,6 @@ repos:
     -   id: no-commit-to-branch
         args: [--branch, develop, --branch, master, --branch, main, --pattern, release/.*]
 -   repo: https://github.com/psf/black
-    rev: 20.8b1
+    rev: 21.5b2
     hooks:
     -   id: black

--- a/pidgin/app.py
+++ b/pidgin/app.py
@@ -272,10 +272,23 @@ def send_query(query_txt):
     auth = flask.request.headers.get("Authorization")
     query = {"query": query_txt}
     response = requests.post(api_url, headers={"Authorization": auth}, json=query)
-    data = response.json()
 
-    if response.status_code == 401 or response.status_code == 403:
-        raise AuthenticationException(data["message"])
+    if response.status_code != 200:
+        logger.error(f"Cannot get data from Peregrine. Code: {response.status_code}.")
+        logger.error(f"Query: {query_txt}")
+        try:
+            logger.error(f"Response: {response.text}")
+        except Exception:
+            pass
+        if response.status_code == 401 or response.status_code == 403:
+            raise AuthenticationException("Unauthorized")
+        raise PidginException("Cannot get data from Peregrine")
+
+    try:
+        data = response.json()
+    except ValueError:
+        logger.error(f"Cannot get JSON from Peregrine response: {response.text}")
+        data = {}
 
     return data
 

--- a/pidgin/app.py
+++ b/pidgin/app.py
@@ -24,7 +24,7 @@ app_info = {
     },
 }
 
-logger = get_logger(__name__, log_level="info")
+logger = get_logger(__name__, log_level="debug")
 
 
 @app.route("/<path:object_id>")
@@ -265,6 +265,7 @@ def send_query(query_txt):
     """
     Send a query to peregrine and return the jsonified response.
     """
+    logger.debug(f"Query: {query_txt}")
     api_url = app.config.get("API_URL")
     if not api_url:
         raise PidginException("Pidgin is not configured with API_URL")
@@ -274,15 +275,15 @@ def send_query(query_txt):
     response = requests.post(api_url, headers={"Authorization": auth}, json=query)
 
     if response.status_code != 200:
-        logger.error(f"Cannot get data from Peregrine. Code: {response.status_code}.")
-        logger.error(f"Query: {query_txt}")
+        logger.error(
+            f"Non-200 response from Peregrine; will still try to parse data. Status code: {response.status_code}."
+        )
         try:
             logger.error(f"Response: {response.text}")
         except Exception:
             pass
         if response.status_code == 401 or response.status_code == 403:
             raise AuthenticationException("Unauthorized")
-        raise PidginException("Cannot get data from Peregrine")
 
     try:
         data = response.json()

--- a/tests/app_test.py
+++ b/tests/app_test.py
@@ -1,11 +1,11 @@
 import pytest
-from pidgin.app import *
-from pidgin.errors import NoCoreMetadataException
+from pidgin import app as _app
+from pidgin.errors import PidginException, NoCoreMetadataException
 
 
 def test_translate_dict_to_bibtex():
     input = {"object_id": "object_id_test", "key2": "value2", "key3": "value3"}
-    output = translate_dict_to_bibtex(input)
+    output = _app.translate_dict_to_bibtex(input)
     expected = '@misc {object_id_test, object_id = "object_id_test", key2 = "value2", key3 = "value3"}'
     assert output == expected
 
@@ -24,7 +24,7 @@ def test_flatten_dict():
             ]
         }
     }
-    output = flatten_dict(input)
+    output = _app.flatten_dict(input)
     expected = {
         "creator": "creator_test",
         "description": "description_test",
@@ -49,7 +49,7 @@ def test_flatten_dict_without_core_metadata():
             ]
         }
     }
-    output = flatten_dict(input1)
+    output = _app.flatten_dict(input1)
     expected = {"file_name_test": "file_name", "object_id": "object_id_test"}
     assert output == expected
 
@@ -60,7 +60,7 @@ def test_flatten_dict_without_core_metadata():
             ]
         }
     }
-    output = flatten_dict(input2)
+    output = _app.flatten_dict(input2)
     assert output == expected
 
 
@@ -70,5 +70,11 @@ def test_flatten_dict_raises_exception():
     """
     input = {"data": "null", "errors": ["error_details_test"]}
     with pytest.raises(NoCoreMetadataException) as e:
-        flatten_dict(input)
+        _app.flatten_dict(input)
     assert "error_details_test" in e.value.args[0]
+
+
+def test_peregrine_error(app):
+    app.config["API_URL"] = "https://google.com"
+    with pytest.raises(PidginException):
+        _app.send_query("{}")

--- a/tests/app_test.py
+++ b/tests/app_test.py
@@ -75,6 +75,9 @@ def test_flatten_dict_raises_exception():
 
 
 def test_peregrine_error(app):
+    """
+    If Peregrine (at API_URL) does not return valid data, Pidgin
+    should not crash.
+    """
     app.config["API_URL"] = "https://google.com"
-    with pytest.raises(PidginException):
-        _app.send_query("{}")
+    _app.send_query("{}")


### PR DESCRIPTION
relates to https://github.com/uc-cdis/peregrine/pull/178 and https://github.com/uc-cdis/data-portal/pull/910

### Improvements
- Do not crash when Peregrine returns a non-200 code, and try to parse the data anyway
