### PR TITLE
PXP-10708 Deployment notes for release automation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Pidgin
 
-A core metadata service
+A core metadata service.
 
 **DEPRECATED: The Pidgin functionality is now available in the [Peregrine service](https://github.com/uc-cdis/peregrine), versions 3.2.0/2023.04 or newer. It is now unnecessary to deploy the Pidgin service.**
 


### PR DESCRIPTION
Jira Ticket: [PXP-10708](https://ctds-planx.atlassian.net/browse/PXP-10708)

### Deployment changes
- If you are seeing this message, you are deploying the Pidgin service after it has been deprecated. If you are using Peregrine version 3.2.0/2023.04 or newer AND data-portal version 5.4.2/2023.05 or newer, the Pidgin service can and should be removed.


[PXP-10708]: https://ctds-planx.atlassian.net/browse/PXP-10708?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ